### PR TITLE
storybook static 디렉토리 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+/storybook
 
 # local env files
 .env.local

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "storybook:build": "vue-cli-service storybook:build -c config/storybook",
+    "storybook:build": "vue-cli-service storybook:build -o storybook -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c config/storybook"
   },
   "dependencies": {


### PR DESCRIPTION
storybook 빌드 수행 시 출력 디렉토리를 `storybook` 으로 변경 및 커밋 대상에서 무시할 수 있도록 `.gitignore` 파일에도 해당 내용 추가했습니다.