### PR TITLE
api 호출시 authentication 인증 여부 확인 가능하도록 공통 interceptor 추가

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,28 @@ import store from './store';
 Vue.config.productionTip = false;
 Vue.prototype.$http = axios;
 
+axios.defaults.withCredentials = true;
+
+axios.interceptors.response.use(response => response, (error) => {
+  if (error.response.status === 401 && error.config.url.startsWith(`${process.env.VUE_APP_API_HOST}`)) {
+    // TODO server api 응답 형식 변경되면 에러코드에 따라 login / join 페이지로 구분되어 이동하도록 변경
+    router.push('login');
+    return Promise.resolve();
+  }
+  return Promise.reject(error);
+});
+
+router.beforeEach((to, from, next) => {
+  if (to.matched.some(routeInfo => routeInfo.meta.authRequired)) {
+    // TODO 별도로 api를 호출하지는 않지만 auth check 가 필요한 페이지가 있으면 인증여부 확인하는 api가 통과된 경우에만 이동 가능하도록
+    axios.get(`${process.env.VUE_APP_API_HOST}/v1/authentication`).then(() => {
+      next();
+    });
+  } else {
+    next(); // 페이지 전환
+  }
+});
+
 new Vue({
   router,
   store,

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 import Home from './views/Home.vue';
+import Login from './views/Login.vue';
 
 Vue.use(Router);
 
@@ -12,6 +13,14 @@ export default new Router({
       path: '/',
       name: 'home',
       component: Home,
+      meta: {
+        authRequired: true,
+      },
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: Login,
     },
   ],
 });


### PR DESCRIPTION
front에서 API호출시 전처리로 인증여부 검사하도록 추가하였습니다.
- api에서 401 응답을 내려주면 login 페이지로 이동 ( 서버 작업에 따라 login / join 페이지로 구분 이동 필요)
- api호출이 필요없는 페이지는 router에 meta정보를 셋팅하여 별도의 인증 확인 api를 호출할 수 있도록 추가