### PR TITLE
NodeJS 라이브러리 취약점 개선 버전 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,12 @@
             "lodash": "^4.17.11",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+          "dev": true
         }
       }
     },
@@ -2816,7 +2822,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "chardet": {
           "version": "0.4.2",
@@ -3046,6 +3053,7 @@
           "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -4288,7 +4296,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/acorn-jsx/download/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "optional": true,
@@ -4298,7 +4306,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true,
           "optional": true
@@ -4368,7 +4376,7 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
@@ -4414,7 +4422,7 @@
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/ansi-html/download/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
@@ -4435,7 +4443,7 @@
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/any-promise/download/any-promise-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
@@ -4517,7 +4525,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/array-equal/download/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -4535,7 +4543,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/array-flatten/download/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -4618,7 +4626,7 @@
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npm.taobao.org/asn1/download/asn1-0.2.4.tgz",
+      "resolved": "http://registry.npm.taobao.org/asn1/download/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
@@ -4664,7 +4672,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
@@ -4688,7 +4696,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/async/download/async-1.5.2.tgz?cache=0&sync_timestamp=1561267760448&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fasync%2Fdownload%2Fasync-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -4706,7 +4714,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -4733,13 +4741,13 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npm.taobao.org/aws-sign2/download/aws-sign2-0.7.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/aws-sign2/download/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://registry.npm.taobao.org/aws4/download/aws4-1.8.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/aws4/download/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
@@ -5117,7 +5125,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npm.taobao.org/babel-plugin-syntax-object-rest-spread/download/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -5147,7 +5155,7 @@
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
-      "resolved": "https://registry.npm.taobao.org/babel-plugin-transform-object-rest-spread/download/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
@@ -5355,13 +5363,13 @@
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/batch/download/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -5433,7 +5441,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -5447,7 +5455,7 @@
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "https://registry.npm.taobao.org/bonjour/download/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
@@ -5469,7 +5477,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
@@ -5736,13 +5744,13 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/call-me-maybe/download/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/caller-callsite/download/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -5766,7 +5774,7 @@
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/camel-case/download/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -5812,7 +5820,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -6215,15 +6223,16 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/clone/download/clone-1.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fclone%2Fdownload%2Fclone-1.0.4.tgz",
+      "resolved": "http://registry.npm.taobao.org/clone/download/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -6472,7 +6481,7 @@
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "http://registry.npm.taobao.org/cookie-signature/download/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
@@ -6870,7 +6879,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npm.taobao.org/css-color-names/download/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -6990,13 +6999,13 @@
     },
     "css-unit-converter": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/css-unit-converter/download/css-unit-converter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
       "dev": true
     },
     "css-url-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/css-url-regex/download/css-url-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
       "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
       "dev": true
     },
@@ -7064,13 +7073,13 @@
     },
     "cssnano-util-get-arguments": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
       "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
       "dev": true
     },
     "cssnano-util-get-match": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
       "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
       "dev": true
     },
@@ -7133,19 +7142,19 @@
     },
     "current-script-polyfill": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/current-script-polyfill/download/current-script-polyfill-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/current-script-polyfill/-/current-script-polyfill-1.0.0.tgz",
       "integrity": "sha1-8xz35PPiGLBybnOMqSoC00iO9hU=",
       "dev": true
     },
     "cyclist": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/cyclist/download/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -7186,7 +7195,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdecamelize%2Fdownload%2Fdecamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -7241,7 +7250,7 @@
     },
     "defaults": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/defaults/download/defaults-1.0.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/defaults/download/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
@@ -7338,7 +7347,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -7357,7 +7366,7 @@
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/depd/download/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
@@ -7373,7 +7382,7 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "http://registry.npm.taobao.org/destroy/download/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
@@ -7429,7 +7438,7 @@
     },
     "dir-glob": {
       "version": "2.2.2",
-      "resolved": "https://registry.npm.taobao.org/dir-glob/download/dir-glob-2.2.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/dir-glob/download/dir-glob-2.2.2.tgz",
       "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
       "dev": true,
       "requires": {
@@ -7438,7 +7447,7 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/dns-equal/download/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
@@ -7454,7 +7463,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/dns-txt/download/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
@@ -7592,7 +7601,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/duplexer/download/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -7610,13 +7619,13 @@
     },
     "easy-stack": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/easy-stack/download/easy-stack-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/easy-stack/download/easy-stack-1.0.0.tgz",
       "integrity": "sha1-EskbMIWjfwuqM26UhurEv5Tj54g=",
       "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/ecc-jsbn/download/ecc-jsbn-0.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/ecc-jsbn/download/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -7626,7 +7635,7 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/ee-first/download/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
@@ -7732,7 +7741,7 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/encodeurl/download/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
@@ -7837,7 +7846,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/escape-html/download/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
@@ -8482,13 +8491,13 @@
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/etag/download/etag-1.8.1.tgz?cache=0&other_urls=http%3A%2F%2Fregistry.npm.taobao.org%2Fetag%2Fdownload%2Fetag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-pubsub": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/event-pubsub/download/event-pubsub-4.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/event-pubsub/download/event-pubsub-4.3.0.tgz",
       "integrity": "sha1-9o2Ba8KfHsAsU53FjI3UDOcss24=",
       "dev": true
     },
@@ -8525,7 +8534,7 @@
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/execa/download/execa-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/execa/download/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
@@ -8637,7 +8646,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -8651,7 +8660,7 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/extend/download/extend-3.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/extend/download/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
@@ -8754,7 +8763,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -8854,7 +8863,7 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/file-entry-cache/download/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "optional": true,
@@ -8954,7 +8963,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -9061,13 +9070,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/for-in/download/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/forever-agent/download/forever-agent-0.6.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/forever-agent/download/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -9089,7 +9098,7 @@
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://registry.npm.taobao.org/form-data/download/form-data-2.3.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/form-data/download/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
@@ -9106,7 +9115,7 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/forwarded/download/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
@@ -9121,13 +9130,13 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/fresh/download/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/from2/download/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -9165,7 +9174,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "http://registry.npm.taobao.org/fs-write-stream-atomic/download/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -9201,7 +9210,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9222,12 +9232,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9242,17 +9254,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9369,7 +9384,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9381,6 +9397,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9395,6 +9412,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9402,12 +9420,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9426,6 +9446,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9506,7 +9527,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9518,6 +9540,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9603,7 +9626,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9639,6 +9663,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9658,6 +9683,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9701,12 +9727,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9812,7 +9840,7 @@
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-4.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/get-stream/download/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
@@ -9827,7 +9855,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -9871,7 +9899,7 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/glob-to-regexp/download/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
@@ -9995,7 +10023,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/pify/download/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -10009,13 +10037,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/har-schema/download/har-schema-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/har-schema/download/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://registry.npm.taobao.org/har-validator/download/har-validator-5.1.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/har-validator/download/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
@@ -10111,7 +10139,7 @@
     },
     "hash-sum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
       "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
       "dev": true
     },
@@ -10201,7 +10229,7 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npm.taobao.org/hpack.js/download/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -10213,13 +10241,13 @@
     },
     "hsl-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsl-regex/download/hsl-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
       "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
       "dev": true
     },
     "hsla-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsla-regex/download/hsla-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
     },
@@ -10240,7 +10268,7 @@
     },
     "html-entities": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/html-entities/download/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
@@ -10316,7 +10344,7 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npm.taobao.org/http-deceiver/download/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
@@ -10364,7 +10392,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -10390,7 +10418,7 @@
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/icss-replace-symbols/download/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
     },
@@ -10411,7 +10439,7 @@
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "http://registry.npm.taobao.org/iferr/download/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
@@ -10429,7 +10457,7 @@
     },
     "import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/import-cwd/download/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
@@ -10438,7 +10466,7 @@
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/import-fresh/download/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
@@ -10448,7 +10476,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -10456,7 +10484,7 @@
     },
     "import-from": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/import-from/download/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
@@ -10465,7 +10493,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -10489,7 +10517,7 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/indexes-of/download/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
@@ -10587,13 +10615,13 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "resolved": "http://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/ip-regex/download/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
@@ -10605,7 +10633,7 @@
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
@@ -10683,7 +10711,7 @@
     },
     "is-color-stop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-color-stop/download/is-color-stop-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
@@ -10748,7 +10776,7 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/is-directory/download/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
@@ -10823,7 +10851,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-obj/download/is-obj-1.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-obj%2Fdownload%2Fis-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -10859,7 +10887,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -10889,7 +10917,7 @@
     },
     "is-regexp": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-regexp/download/is-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
@@ -10931,7 +10959,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
@@ -10961,7 +10989,7 @@
     },
     "isemail": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/isemail/download/isemail-3.2.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/isemail/download/isemail-3.2.0.tgz",
       "integrity": "sha1-WTEKAhkxqfsGu7UeFVzgs/I2gyw=",
       "dev": true,
       "requires": {
@@ -10992,13 +11020,13 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "javascript-stringify": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/javascript-stringify/download/javascript-stringify-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-1.6.0.tgz",
       "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=",
       "dev": true
     },
@@ -11021,13 +11049,13 @@
     },
     "js-message": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/js-message/download/js-message-1.0.5.tgz",
+      "resolved": "http://registry.npm.taobao.org/js-message/download/js-message-1.0.5.tgz",
       "integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU=",
       "dev": true
     },
     "js-queue": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/js-queue/download/js-queue-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/js-queue/download/js-queue-2.0.0.tgz",
       "integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=",
       "dev": true,
       "requires": {
@@ -11052,7 +11080,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
@@ -11104,7 +11132,7 @@
     },
     "jsdom-global": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/jsdom-global/download/jsdom-global-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
       "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
       "dev": true
     },
@@ -11122,7 +11150,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
@@ -11134,7 +11162,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stable-stringify/download/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -11149,7 +11177,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -11185,7 +11213,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.taobao.org/jsprim/download/jsprim-1.4.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/jsprim/download/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -11218,7 +11246,7 @@
     },
     "launch-editor": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/launch-editor/download/launch-editor-2.2.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/launch-editor/download/launch-editor-2.2.1.tgz",
       "integrity": "sha1-hxtaPuOdZoD8wm03kwtu7aidsMo=",
       "dev": true,
       "requires": {
@@ -11316,7 +11344,7 @@
       "dependencies": {
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npm.taobao.org/find-cache-dir/download/find-cache-dir-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
@@ -11327,7 +11355,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz?cache=0&sync_timestamp=1560752359985&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffind-up%2Fdownload%2Ffind-up-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -11337,7 +11365,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -11346,7 +11374,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/pkg-dir/download/pkg-dir-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
@@ -11394,9 +11422,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "http://registry.npm.taobao.org/lodash/download/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash-es": {
@@ -11407,7 +11435,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/lodash._reinterpolate/download/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
@@ -11424,9 +11452,9 @@
       "dev": true
     },
     "lodash.defaultsdeep": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.defaultsdeep/download/lodash.defaultsdeep-4.6.0.tgz",
-      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "lodash.get": {
@@ -11443,13 +11471,13 @@
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/lodash.kebabcase/download/lodash.kebabcase-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
@@ -11467,13 +11495,13 @@
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.sortby/download/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {
       "version": "4.4.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.template/download/lodash.template-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
@@ -11483,7 +11511,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.templatesettings/download/lodash.templatesettings-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
@@ -11498,19 +11526,19 @@
     },
     "lodash.transform": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.transform/download/lodash.transform-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/log-symbols/download/log-symbols-2.2.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/log-symbols/download/log-symbols-2.2.0.tgz?cache=0&other_urls=http%3A%2F%2Fregistry.npm.taobao.org%2Flog-symbols%2Fdownload%2Flog-symbols-2.2.0.tgz",
       "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "dev": true,
       "requires": {
@@ -11534,7 +11562,7 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "http://registry.npm.taobao.org/lower-case/download/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
@@ -11638,7 +11666,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/media-typer/download/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -11678,7 +11706,7 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
@@ -11707,7 +11735,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/methods/download/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
@@ -11855,9 +11883,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "http://registry.npm.taobao.org/mixin-deep/download/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -11866,8 +11894,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -12036,7 +12064,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/move-concurrently/download/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -12066,7 +12094,7 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
@@ -12164,7 +12192,7 @@
     },
     "node-ipc": {
       "version": "9.1.1",
-      "resolved": "https://registry.npm.taobao.org/node-ipc/download/node-ipc-9.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/node-ipc/download/node-ipc-9.1.1.tgz",
       "integrity": "sha1-TiRe1pOOZRAOWV68XcNLFujdXWk=",
       "dev": true,
       "requires": {
@@ -12256,7 +12284,7 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
@@ -12298,7 +12326,7 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/num2fraction/download/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
@@ -12316,13 +12344,13 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npm.taobao.org/oauth-sign/download/oauth-sign-0.9.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/oauth-sign/download/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
@@ -12453,7 +12481,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/on-finished/download/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -12501,7 +12529,7 @@
     },
     "opn": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/opn/download/opn-5.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fopn%2Fdownload%2Fopn-5.5.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/opn/download/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "dev": true,
       "requires": {
@@ -12524,7 +12552,7 @@
     },
     "ora": {
       "version": "3.4.0",
-      "resolved": "https://registry.npm.taobao.org/ora/download/ora-3.4.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/ora/download/ora-3.4.0.tgz",
       "integrity": "sha1-vwdSSRBZo+8+1MhQl1Md6f280xg=",
       "dev": true,
       "requires": {
@@ -12620,7 +12648,7 @@
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-defer/download/p-defer-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-defer%2Fdownload%2Fp-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
@@ -12683,7 +12711,7 @@
     },
     "parallel-transform": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/parallel-transform/download/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
@@ -12694,7 +12722,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/param-case/download/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -12748,7 +12776,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/parse-json/download/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -12818,7 +12846,7 @@
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
@@ -12872,13 +12900,13 @@
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/pinkie/download/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -13490,7 +13518,7 @@
     },
     "prepend-http": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/prepend-http/download/prepend-http-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
@@ -13502,13 +13530,13 @@
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/pretty-bytes/download/pretty-bytes-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
     "pretty-error": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/pretty-error/download/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
@@ -13566,7 +13594,7 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/promise-inflight/download/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
@@ -13695,13 +13723,13 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/q/download/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.5.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.5.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/qs/download/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
@@ -14454,7 +14482,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -14462,7 +14490,7 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/relateurl/download/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
@@ -14487,13 +14515,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -14516,7 +14544,7 @@
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "https://registry.npm.taobao.org/request/download/request-2.88.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/request/download/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "dev": true,
       "requires": {
@@ -14544,7 +14572,7 @@
     },
     "request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/request-promise-core/download/request-promise-core-1.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/request-promise-core/download/request-promise-core-1.1.2.tgz",
       "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "dev": true,
       "requires": {
@@ -14553,7 +14581,7 @@
     },
     "request-promise-native": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/request-promise-native/download/request-promise-native-1.0.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/request-promise-native/download/request-promise-native-1.0.7.tgz",
       "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "dev": true,
       "requires": {
@@ -14564,19 +14592,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/require-main-filename/download/require-main-filename-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/require-main-filename/download/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/require-uncached/download/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "optional": true,
@@ -14587,7 +14615,7 @@
       "dependencies": {
         "caller-path": {
           "version": "0.1.0",
-          "resolved": "https://registry.npm.taobao.org/caller-path/download/caller-path-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "dev": true,
           "optional": true,
@@ -14597,14 +14625,14 @@
         },
         "callsites": {
           "version": "0.2.0",
-          "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
           "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
           "dev": true,
           "optional": true
         },
         "resolve-from": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true,
           "optional": true
@@ -14613,13 +14641,13 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "reselect": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/reselect/download/reselect-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
       "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
       "dev": true
     },
@@ -14640,7 +14668,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -14649,7 +14677,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -14685,19 +14713,19 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/retry/download/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "rgb-regex": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/rgb-regex/download/rgb-regex-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
       "dev": true
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/rgba-regex/download/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },
@@ -14731,7 +14759,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/run-queue/download/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -14740,13 +14768,14 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "https://registry.npm.taobao.org/rx-lite/download/rx-lite-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "https://registry.npm.taobao.org/rx-lite-aggregates/download/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "optional": true,
@@ -14829,7 +14858,7 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/select-hose/download/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
@@ -14917,7 +14946,7 @@
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/serve-index/download/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
@@ -14941,7 +14970,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.6.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -14953,7 +14982,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -14984,9 +15013,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/set-value/download/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -14997,7 +15026,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -15086,7 +15115,7 @@
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/simple-swizzle/download/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
@@ -15311,7 +15340,7 @@
     },
     "sort-keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/sort-keys/download/sort-keys-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
@@ -15462,7 +15491,7 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://registry.npm.taobao.org/sshpk/download/sshpk-1.16.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/sshpk/download/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
@@ -15527,7 +15556,7 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/stealthy-require/download/stealthy-require-1.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/stealthy-require/download/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
@@ -15572,13 +15601,13 @@
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/stream-shift/download/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
@@ -15624,7 +15653,7 @@
     },
     "string.prototype.padend": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/string.prototype.padend/download/string.prototype.padend-3.0.0.tgz",
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
@@ -15697,7 +15726,7 @@
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-indent/download/strip-indent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
@@ -15908,7 +15937,7 @@
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "optional": true,
@@ -15921,21 +15950,21 @@
         },
         "ajv-keywords": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
           "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
           "dev": true,
           "optional": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffast-deep-equal%2Fdownload%2Ffast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true,
           "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true,
           "optional": true
@@ -16075,7 +16104,7 @@
     },
     "thenify": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/thenify/download/thenify-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
@@ -16084,7 +16113,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/thenify-all/download/thenify-all-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
@@ -16135,7 +16164,7 @@
     },
     "timsort": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/timsort/download/timsort-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
@@ -16238,7 +16267,7 @@
     },
     "toposort": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/toposort/download/toposort-1.0.7.tgz",
+      "resolved": "http://registry.npm.taobao.org/toposort/download/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
@@ -16253,7 +16282,7 @@
     },
     "tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://registry.npm.taobao.org/tough-cookie/download/tough-cookie-2.4.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/tough-cookie/download/tough-cookie-2.4.3.tgz",
       "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
       "dev": true,
       "requires": {
@@ -16263,7 +16292,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -16271,7 +16300,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/tr46/download/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -16310,7 +16339,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npm.taobao.org/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -16319,7 +16348,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz",
+      "resolved": "http://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
@@ -16379,7 +16408,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "http://registry.npm.taobao.org/typedarray/download/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -16436,49 +16465,26 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/union-value/download/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "http://registry.npm.taobao.org/set-value/download/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/uniq/download/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/uniqs/download/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
@@ -16508,13 +16514,13 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/unpipe/download/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unquote": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/unquote/download/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
       "dev": true
     },
@@ -16566,7 +16572,7 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "http://registry.npm.taobao.org/upper-case/download/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
@@ -16665,13 +16671,13 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/utila/download/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/utils-merge/download/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
@@ -16693,7 +16699,7 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/vary/download/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
@@ -16705,7 +16711,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fverror%2Fdownload%2Fverror-1.10.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -16854,7 +16860,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/w3c-hr-time/download/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
@@ -16903,7 +16909,7 @@
     },
     "wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/wcwidth/download/wcwidth-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/wcwidth/download/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
@@ -17295,7 +17301,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwhich-module%2Fdownload%2Fwhich-module-2.0.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -17573,7 +17579,7 @@
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/write/download/write-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "optional": true,
@@ -17722,7 +17728,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -17733,7 +17739,7 @@
         },
         "execa": {
           "version": "0.8.0",
-          "resolved": "https://registry.npm.taobao.org/execa/download/execa-0.8.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
@@ -17748,7 +17754,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -17764,13 +17770,13 @@
         },
         "normalize-path": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/normalize-path/download/normalize-path-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
           "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }


### PR DESCRIPTION
* AS-IS

```
$ npm audit
...
found 1293 high severity vulnerabilities in 70069 scanned packages
  run `npm audit fix` to fix 1293 of them.
```

* TO-BE
```
$ npm audit
...                                                             
found 0 vulnerabilities
 in 70690 scanned packages
```